### PR TITLE
Potential fix for code scanning alert no. 22: DOM text reinterpreted as HTML

### DIFF
--- a/oauthapp/views/genai/chat.ejs
+++ b/oauthapp/views/genai/chat.ejs
@@ -48,7 +48,10 @@
     function appendMessage(sender, message, ...bgClasses) {
         const messageElement = document.createElement('div');
         messageElement.classList.add('p-2', 'my-2', 'rounded-lg', ...bgClasses);
-        messageElement.innerHTML = `<strong>${sender}:</strong> ${message}`;
+        const senderElement = document.createElement('strong');
+        senderElement.textContent = `${sender}: `;
+        messageElement.appendChild(senderElement);
+        messageElement.appendChild(document.createTextNode(message));
         chatContainer.appendChild(messageElement);
         chatContainer.scrollTop = chatContainer.scrollHeight;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/bibhu2020/oauth/security/code-scanning/22](https://github.com/bibhu2020/oauth/security/code-scanning/22)

To fix the problem, we must ensure that any user-supplied input (specifically, the `message` parameter) is properly escaped before being inserted into the DOM as HTML. The best approach is to avoid using `innerHTML` for user content and instead use DOM methods such as `textContent` to safely insert untrusted content. In this case, we want the sender ("You" or "Bot") to appear bold, followed by the message, and both should be safe from XSS. We can accomplish this by creating a `<strong>` element for the sender label, and a text node for the message, then appending both as children to the message container. This change should be made inside the `appendMessage` function in oauthapp/views/genai/chat.ejs. No new imports or libraries are required, as standard DOM methods suffice.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
